### PR TITLE
fix link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ After adding your libraries and code:
 
 4. Customize the box configuration file (`box-config.json`) if necessary.
 
-See [the Truffle Box section of our documentation](http://truffleframework.com/) for more info.
+See [the Truffle Box section of our documentation](http://truffleframework.com/docs/advanced/truffle-boxes) for more info.


### PR DESCRIPTION
Correct link is http://truffleframework.com/docs/advanced/truffle-boxes