### PR TITLE
Fix link to the Truffle Box section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ After adding your libraries and code:
 
 4. Customize the box configuration file (`box-config.json`) if necessary.
 
-See [the Truffle Box section of our documentation](http://truffleframework.com/) for more info.
+See [the Truffle Box section of our documentation](https://truffleframework.com/docs/truffle/getting-started/truffle-boxes) for more info.


### PR DESCRIPTION
Fix link to the Truffle Box section to point to the section rather than the site.