### PR TITLE
Add default networks in config file

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -1,4 +1,17 @@
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!
+  // The defaults below provide for an easier quick-start with Ganache. 
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 7545,
+      network_id: "*"
+    },
+    test: {
+      host: "127.0.0.1",
+      port: 7545,
+      network_id: "*"
+    }
+  }
 };


### PR DESCRIPTION
so that somebody coming in new and following the instructions (including truffle migrate or truffle test) doesn't get Error: No network specified. Cannot determine current network. The aim of this is to make on-boarding into Truffle easier.

Same PR as https://github.com/truffle-box/metacoin-box/pull/7