### PR TITLE
Remove contracts/.placeholder as it's not needed. Add Solidity syntax highlighting.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity

--- a/contracts/.placeholder
+++ b/contracts/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,4 +1,19 @@
+const path = require("path")
+
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
-  // to customize your Truffle configuration!
-};
+  // for more about customizing your Truffle configuration!
+  contracts_build_directory: path.join(__dirname, "src/contracts"),
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: 8545,
+      network_id: "*" // Match any network id
+    }
+  },
+  compilers: {
+    solc: {
+      version: "0.6.1"
+    }
+  }
+}

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -2,18 +2,5 @@ const path = require("path")
 
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
-  // for more about customizing your Truffle configuration!
-  // contracts_build_directory: path.join(__dirname, "src/contracts"),
-  networks: {
-    development: {
-      host: "127.0.0.1",
-      port: 8545,
-      network_id: "*" // Match any network id
-    }
-  },
-  compilers: {
-    solc: {
-      version: "0.6.1"
-    }
-  }
+  // to customize your Truffle configuration!
 }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,5 +1,3 @@
-const path = require("path")
-
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,4 +1,4 @@
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!
-}
+};

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -3,7 +3,7 @@ const path = require("path")
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // for more about customizing your Truffle configuration!
-  contracts_build_directory: path.join(__dirname, "src/contracts"),
+  // contracts_build_directory: path.join(__dirname, "src/contracts"),
   networks: {
     development: {
       host: "127.0.0.1",


### PR DESCRIPTION
`contracts/.placeholder` was added so that the `contacts` directory would get saved in git. It's not needed because the `contracts/` directory has `contracts/Migration.sol`.

Add .gitattributes so that Github shows Solidity syntax highlighting. I learned about this in [Open Zeppelin's repo](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/.gitattributes)